### PR TITLE
Rectify a typo

### DIFF
--- a/rpi-auto-mount.sh
+++ b/rpi-auto-mount.sh
@@ -110,7 +110,7 @@ createmenu ()
 }
 
 function select_device {
-	devives_list=
+	devices_list=
 
 	for DEVICE in $(sudo blkid -o device); do
 		LABEL=$(sudo blkid -o value -s LABEL $DEVICE)


### PR DESCRIPTION
The change resolves a possible break in code due to inconsistency of spellings of a variable name `devices_list`.